### PR TITLE
Improve data available for evolutions

### DIFF
--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -16,14 +16,10 @@
     },
     "evolutions": [
       {
-        "id": "002",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/7/73/002Ivysaur.png/250px-002Ivysaur.png",
-        "name": "Ivysaur"
+        "id": "002"
       },
       {
-        "id": "003",
-        "imgSrc": "https://bulbapedia.bulbagarden.net/wiki/File:003Venusaur.png",
-        "name": "Venusaur"
+        "id": "003"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/2/21/001Bulbasaur.png/250px-001Bulbasaur.png"
@@ -45,9 +41,7 @@
     },
     "evolutions": [
       {
-        "id": "003",
-        "imgSrc": "https://bulbapedia.bulbagarden.net/wiki/File:003Venusaur.png",
-        "name": "Venusaur"
+        "id": "003"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/7/73/002Ivysaur.png/250px-002Ivysaur.png"
@@ -86,14 +80,10 @@
     },
     "evolutions": [
       {
-        "id": "005",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/4/4a/005Charmeleon.png/250px-005Charmeleon.png",
-        "name": "Charmeleon"
+        "id": "005"
       },
       {
-        "id": "006",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/7/7e/006Charizard.png/250px-006Charizard.png",
-        "name": "Charizard"
+        "id": "006"
       }
     ],
     "imgSrc": "https://bulbapedia.bulbagarden.net/wiki/File:004Charmander.png"
@@ -115,9 +105,7 @@
     },
     "evolutions": [
       {
-        "id": "006",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/7/7e/006Charizard.png/250px-006Charizard.png",
-        "name": "Charizard"
+        "id": "006"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/4/4a/005Charmeleon.png/250px-005Charmeleon.png"
@@ -156,14 +144,10 @@
     },
     "evolutions": [
       {
-        "id": "008",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/0/0c/008Wartortle.png/250px-008Wartortle.png",
-        "name": "Wartortle"
+        "id": "008"
       },
       {
-        "id": "009",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/0/02/009Blastoise.png/250px-009Blastoise.png",
-        "name": "Blastoise"
+        "id": "009"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/3/39/007Squirtle.png/250px-007Squirtle.png"
@@ -185,9 +169,7 @@
     },
     "evolutions": [
       {
-        "id": "009",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/0/02/009Blastoise.png/250px-009Blastoise.png",
-        "name": "Blastoise"
+        "id": "009"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/0/0c/008Wartortle.png/250px-008Wartortle.png"
@@ -226,14 +208,10 @@
     },
     "evolutions": [
       {
-        "id": "011",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/c/cd/011Metapod.png/250px-011Metapod.png",
-        "name": "Metapod"
+        "id": "011"
       },
       {
-        "id": "012",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/d/d1/012Butterfree.png/250px-012Butterfree.png",
-        "name": "Butterfree"
+        "id": "012"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/5/5d/010Caterpie.png/250px-010Caterpie.png"
@@ -255,9 +233,7 @@
     },
     "evolutions": [
       {
-        "id": "012",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/d/d1/012Butterfree.png/250px-012Butterfree.png",
-        "name": "Butterfree"
+        "id": "012"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/c/cd/011Metapod.png/250px-011Metapod.png"
@@ -296,14 +272,10 @@
     },
     "evolutions": [
       {
-        "id": "014",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/f/f0/014Kakuna.png/250px-014Kakuna.png",
-        "name": "Kakuna"
+        "id": "014"
       },
       {
-        "id": "015",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/6/61/015Beedrill.png/250px-015Beedrill.png",
-        "name": "Beedrill"
+        "id": "015"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/d/df/013Weedle.png/250px-013Weedle.png"
@@ -325,9 +297,7 @@
     },
     "evolutions": [
       {
-        "id": "015",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/6/61/015Beedrill.png/250px-015Beedrill.png",
-        "name": "Beedrill"
+        "id": "015"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/f/f0/014Kakuna.png/250px-014Kakuna.png"
@@ -366,14 +336,10 @@
     },
     "evolutions": [
       {
-        "id": "017",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/7/7a/017Pidgeotto.png/250px-017Pidgeotto.png",
-        "name": "Pidgeotto"
+        "id": "017"
       },
       {
-        "id": "018",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/5/57/018Pidgeot.png/250px-018Pidgeot.png",
-        "name": "Pidgeot"
+        "id": "018"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/5/55/016Pidgey.png/250px-016Pidgey.png"
@@ -395,9 +361,7 @@
     },
     "evolutions": [
       {
-        "id": "018",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/5/57/018Pidgeot.png/250px-018Pidgeot.png",
-        "name": "Pidgeot"
+        "id": "018"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/7/7a/017Pidgeotto.png/250px-017Pidgeotto.png"
@@ -436,9 +400,7 @@
     },
     "evolutions": [
       {
-        "id": "020",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/f/f4/020Raticate.png/250px-020Raticate.png",
-        "name": "Raticate"
+        "id": "020"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/4/46/019Rattata.png/250px-019Rattata.png"
@@ -477,9 +439,7 @@
     },
     "evolutions": [
       {
-        "id": "022",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/a/a0/022Fearow.png/250px-022Fearow.png",
-        "name": "Fearow"
+        "id": "022"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/8/8b/021Spearow.png/250px-021Spearow.png"
@@ -518,9 +478,7 @@
     },
     "evolutions": [
       {
-        "id": "024",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/c/cd/024Arbok.png/250px-024Arbok.png",
-        "name": "Arbok"
+        "id": "024"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/f/fa/023Ekans.png/250px-023Ekans.png"
@@ -559,9 +517,7 @@
     },
     "evolutions": [
       {
-        "id": "026",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/8/88/026Raichu.png/250px-026Raichu.png",
-        "name": "Raichu"
+        "id": "026"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/0/0d/025Pikachu.png/250px-025Pikachu.png"
@@ -600,9 +556,7 @@
     },
     "evolutions": [
       {
-        "id": "028",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/0/0b/028Sandslash.png/250px-028Sandslash.png",
-        "name": "Sandslash"
+        "id": "028"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/9/9e/027Sandshrew.png/250px-027Sandshrew.png"
@@ -641,14 +595,10 @@
     },
     "evolutions": [
       {
-        "id": "030",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/c/cd/030Nidorina.png/250px-030Nidorina.png",
-        "name": "Nidorina"
+        "id": "030"
       },
       {
-        "id": "031",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/b/bf/031Nidoqueen.png/250px-031Nidoqueen.png",
-        "name": "Nidoqueen"
+        "id": "031"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/8/81/029Nidoran.png/250px-029Nidoran.png"
@@ -670,9 +620,7 @@
     },
     "evolutions": [
       {
-        "id": "031",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/b/bf/031Nidoqueen.png/250px-031Nidoqueen.png",
-        "name": "Nidoqueen"
+        "id": "031"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/c/cd/030Nidorina.png/250px-030Nidorina.png"
@@ -711,14 +659,10 @@
     },
     "evolutions": [
       {
-        "id": "033",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/9/9f/033Nidorino.png/250px-033Nidorino.png",
-        "name": "Nidorino"
+        "id": "033"
       },
       {
-        "id": "034",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/c/c6/034Nidoking.png/250px-034Nidoking.png",
-        "name": "Nidoking"
+        "id": "034"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/4/4a/032Nidoran.png/250px-032Nidoran.png"
@@ -740,9 +684,7 @@
     },
     "evolutions": [
       {
-        "id": "034",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/c/c6/034Nidoking.png/250px-034Nidoking.png",
-        "name": "Nidoking"
+        "id": "034"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/9/9f/033Nidorino.png/250px-033Nidorino.png"
@@ -781,9 +723,7 @@
     },
     "evolutions": [
       {
-        "id": "036",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/a/a9/036Clefable.png/250px-036Clefable.png",
-        "name": "Clefable"
+        "id": "036"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/f/f4/035Clefairy.png/250px-035Clefairy.png"
@@ -822,9 +762,7 @@
     },
     "evolutions": [
       {
-        "id": "038",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/0/05/038Ninetales.png/250px-038Ninetales.png",
-        "name": "Ninetales"
+        "id": "038"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/6/60/037Vulpix.png/250px-037Vulpix.png"
@@ -863,9 +801,7 @@
     },
     "evolutions": [
       {
-        "id": "040",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/9/92/040Wigglytuff.png/250px-040Wigglytuff.png",
-        "name": "Wigglytuff"
+        "id": "040"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/3/3e/039Jigglypuff.png/250px-039Jigglypuff.png"
@@ -904,9 +840,7 @@
     },
     "evolutions": [
       {
-        "id": "042",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/0/0c/042Golbat.png/250px-042Golbat.png",
-        "name": "Golbat"
+        "id": "042"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/d/da/041Zubat.png/250px-041Zubat.png"
@@ -945,14 +879,10 @@
     },
     "evolutions": [
       {
-        "id": "044",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/2/2a/044Gloom.png/250px-044Gloom.png",
-        "name": "Gloom"
+        "id": "044"
       },
       {
-        "id": "045",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/6/6a/045Vileplume.png/250px-045Vileplume.png",
-        "name": "Vileplume"
+        "id": "045"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/4/43/043Oddish.png/250px-043Oddish.png"
@@ -974,9 +904,7 @@
     },
     "evolutions": [
       {
-        "id": "045",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/6/6a/045Vileplume.png/250px-045Vileplume.png",
-        "name": "Vileplume"
+        "id": "045"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/2/2a/044Gloom.png/250px-044Gloom.png"
@@ -1015,9 +943,7 @@
     },
     "evolutions": [
       {
-        "id": "047",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/8/80/047Parasect.png/250px-047Parasect.png",
-        "name": "Parasect"
+        "id": "047"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/d/d4/046Paras.png/250px-046Paras.png"
@@ -1056,9 +982,7 @@
     },
     "evolutions": [
       {
-        "id": "049",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/d/d3/049Venomoth.png/250px-049Venomoth.png",
-        "name": "Venomoth"
+        "id": "049"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/a/ad/048Venonat.png/250px-048Venonat.png"
@@ -1097,9 +1021,7 @@
     },
     "evolutions": [
       {
-        "id": "051",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/e/e5/051Dugtrio.png/250px-051Dugtrio.png",
-        "name": "Dugtrio"
+        "id": "051"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/3/31/050Diglett.png/250px-050Diglett.png"
@@ -1138,9 +1060,7 @@
     },
     "evolutions": [
       {
-        "id": "053",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/1/13/053Persian.png/250px-053Persian.png",
-        "name": "Persian"
+        "id": "053"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/d/d6/052Meowth.png/250px-052Meowth.png"
@@ -1179,9 +1099,7 @@
     },
     "evolutions": [
       {
-        "id": "055",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/f/fe/055Golduck.png/250px-055Golduck.png",
-        "name": "Golduck"
+        "id": "055"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/5/53/054Psyduck.png/250px-054Psyduck.png"
@@ -1220,9 +1138,7 @@
     },
     "evolutions": [
       {
-        "id": "057",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/9/9a/057Primeape.png/250px-057Primeape.png",
-        "name": "Primeape"
+        "id": "057"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/4/41/056Mankey.png/250px-056Mankey.png"
@@ -1261,9 +1177,7 @@
     },
     "evolutions": [
       {
-        "id": "059",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/b/b8/059Arcanine.png/250px-059Arcanine.png",
-        "name": "Arcanine"
+        "id": "059"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/3/3d/058Growlithe.png/250px-058Growlithe.png"
@@ -1302,14 +1216,10 @@
     },
     "evolutions": [
       {
-        "id": "061",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/a/a9/061Poliwhirl.png/250px-061Poliwhirl.png",
-        "name": "Poliwhirl"
+        "id": "061"
       },
       {
-        "id": "062",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/2/2d/062Poliwrath.png/250px-062Poliwrath.png",
-        "name": "Poliwrath"
+        "id": "062"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/4/49/060Poliwag.png/250px-060Poliwag.png"
@@ -1331,9 +1241,7 @@
     },
     "evolutions": [
       {
-        "id": "062",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/2/2d/062Poliwrath.png/250px-062Poliwrath.png",
-        "name": "Poliwrath"
+        "id": "062"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/a/a9/061Poliwhirl.png/250px-061Poliwhirl.png"
@@ -1372,14 +1280,10 @@
     },
     "evolutions": [
       {
-        "id": "064",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/9/97/064Kadabra.png/250px-064Kadabra.png",
-        "name": "Kadabra"
+        "id": "064"
       },
       {
-        "id": "065",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/c/cc/065Alakazam.png/250px-065Alakazam.png",
-        "name": "Alakazam"
+        "id": "065"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/6/62/063Abra.png/250px-063Abra.png"
@@ -1401,9 +1305,7 @@
     },
     "evolutions": [
       {
-        "id": "065",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/c/cc/065Alakazam.png/250px-065Alakazam.png",
-        "name": "Alakazam"
+        "id": "065"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/9/97/064Kadabra.png/250px-064Kadabra.png"
@@ -1442,14 +1344,10 @@
     },
     "evolutions": [
       {
-        "id": "067",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/8/8e/067Machoke.png/250px-067Machoke.png",
-        "name": "Machoke"
+        "id": "067"
       },
       {
-        "id": "068",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/8/8f/068Machamp.png/250px-068Machamp.png",
-        "name": "Machamp"
+        "id": "068"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/8/85/066Machop.png/250px-066Machop.png"
@@ -1471,9 +1369,7 @@
     },
     "evolutions": [
       {
-        "id": "068",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/8/8f/068Machamp.png/250px-068Machamp.png",
-        "name": "Machamp"
+        "id": "068"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/8/8e/067Machoke.png/250px-067Machoke.png"
@@ -1512,14 +1408,10 @@
     },
     "evolutions": [
       {
-        "id": "070",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/9/9f/070Weepinbell.png/250px-070Weepinbell.png",
-        "name": "Weepinbell"
+        "id": "070"
       },
       {
-        "id": "071",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/b/be/071Victreebel.png/250px-071Victreebel.png",
-        "name": "Victreebel"
+        "id": "071"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/a/a2/069Bellsprout.png/250px-069Bellsprout.png"
@@ -1541,9 +1433,7 @@
     },
     "evolutions": [
       {
-        "id": "071",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/b/be/071Victreebel.png/250px-071Victreebel.png",
-        "name": "Victreebel"
+        "id": "071"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/9/9f/070Weepinbell.png/250px-070Weepinbell.png"
@@ -1591,9 +1481,7 @@
     },
     "evolutions": [
       {
-        "id": "073",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/f/f6/073Tentacruel.png/250px-073Tentacruel.png",
-        "name": "Tentacruel"
+        "id": "073"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/4/4e/072Tentacool.png/250px-072Tentacool.png"
@@ -1641,14 +1529,10 @@
     },
     "evolutions": [
       {
-        "id": "075",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/7/75/075Graveler.png/250px-075Graveler.png",
-        "name": "Graveler"
+        "id": "075"
       },
       {
-        "id": "076",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/f/f2/076Golem.png/250px-076Golem.png",
-        "name": "Golem"
+        "id": "076"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/9/98/074Geodude.png/250px-074Geodude.png"
@@ -1670,9 +1554,7 @@
     },
     "evolutions": [
       {
-        "id": "076",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/f/f2/076Golem.png/250px-076Golem.png",
-        "name": "Golem"
+        "id": "076"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/7/75/075Graveler.png/250px-075Graveler.png"
@@ -1711,9 +1593,7 @@
     },
     "evolutions": [
       {
-        "id": "078",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/3/3f/078Rapidash.png/250px-078Rapidash.png",
-        "name": "Rapidash"
+        "id": "078"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/3/3b/077Ponyta.png/250px-077Ponyta.png"
@@ -1752,9 +1632,7 @@
     },
     "evolutions": [
       {
-        "id": "080",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/8/80/080Slowbro.png/250px-080Slowbro.png",
-        "name": "Slowbro"
+        "id": "080"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/7/70/079Slowpoke.png/250px-079Slowpoke.png"
@@ -1806,9 +1684,7 @@
     },
     "evolutions": [
       {
-        "id": "082",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/7/72/082Magneton.png/250px-082Magneton.png",
-        "name": "Magneton"
+        "id": "082"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/6/6c/081Magnemite.png/250px-081Magnemite.png"
@@ -1877,9 +1753,7 @@
     },
     "evolutions": [
       {
-        "id": "085",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/9/93/085Dodrio.png/250px-085Dodrio.png",
-        "name": "Dodrio"
+        "id": "085"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/5/54/084Doduo.png/250px-084Doduo.png"
@@ -1918,9 +1792,7 @@
     },
     "evolutions": [
       {
-        "id": "087",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/c/c7/087Dewgong.png/250px-087Dewgong.png",
-        "name": "Dewgong"
+        "id": "087"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/1/1f/086Seel.png/250px-086Seel.png"
@@ -1959,9 +1831,7 @@
     },
     "evolutions": [
       {
-        "id": "089",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/7/7c/089Muk.png/250px-089Muk.png",
-        "name": "Muk"
+        "id": "089"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/a/a0/088Grimer.png/250px-088Grimer.png"
@@ -2000,9 +1870,7 @@
     },
     "evolutions": [
       {
-        "id": "091",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/1/1d/091Cloyster.png/250px-091Cloyster.png",
-        "name": "Cloyster"
+        "id": "091"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/4/40/090Shellder.png/250px-090Shellder.png"
@@ -2041,14 +1909,10 @@
     },
     "evolutions": [
       {
-        "id": "093",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/6/62/093Haunter.png/250px-093Haunter.png",
-        "name": "Haunter"
+        "id": "093"
       },
       {
-        "id": "094",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/c/c6/094Gengar.png/250px-094Gengar.png",
-        "name": "Gengar"
+        "id": "094"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/c/ca/092Gastly.png/250px-092Gastly.png"
@@ -2070,9 +1934,7 @@
     },
     "evolutions": [
       {
-        "id": "094",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/c/c6/094Gengar.png/250px-094Gengar.png",
-        "name": "Gengar"
+        "id": "094"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/6/62/093Haunter.png/250px-093Haunter.png"
@@ -2128,9 +1990,7 @@
     },
     "evolutions": [
       {
-        "id": "097",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/0/0a/097Hypno.png/250px-097Hypno.png",
-        "name": "Hypno"
+        "id": "097"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/3/3e/096Drowzee.png/250px-096Drowzee.png"
@@ -2169,9 +2029,7 @@
     },
     "evolutions": [
       {
-        "id": "099",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/7/71/099Kingler.png/250px-099Kingler.png",
-        "name": "Kingler"
+        "id": "099"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/a/a7/098Krabby.png/250px-098Krabby.png"
@@ -2210,9 +2068,7 @@
     },
     "evolutions": [
       {
-        "id": "101",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/8/84/101Electrode.png/250px-101Electrode.png",
-        "name": "Electrode"
+        "id": "101"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/d/da/100Voltorb.png/250px-100Voltorb.png"
@@ -2258,9 +2114,7 @@
     },
     "evolutions": [
       {
-        "id": "103",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/2/24/103Exeggutor.png/250px-103Exeggutor.png",
-        "name": "Exeggutor"
+        "id": "103"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/a/af/102Exeggcute.png/250px-102Exeggcute.png"
@@ -2306,9 +2160,7 @@
     },
     "evolutions": [
       {
-        "id": "105",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/9/98/105Marowak.png/250px-105Marowak.png",
-        "name": "Marowak"
+        "id": "105"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/2/2a/104Cubone.png/250px-104Cubone.png"
@@ -2398,9 +2250,7 @@
     },
     "evolutions": [
       {
-        "id": "110",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/4/42/110Weezing.png/250px-110Weezing.png",
-        "name": "Weezing"
+        "id": "110"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/1/17/109Koffing.png/250px-109Koffing.png"
@@ -2439,9 +2289,7 @@
     },
     "evolutions": [
       {
-        "id": "112",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/4/47/112Rhydon.png/250px-112Rhydon.png",
-        "name": "Rhydon"
+        "id": "112"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/9/9b/111Rhyhorn.png/250px-111Rhyhorn.png"
@@ -2531,9 +2379,7 @@
     },
     "evolutions": [
       {
-        "id": "117",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/2/26/117Seadra.png/250px-117Seadra.png",
-        "name": "Seadra"
+        "id": "117"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/5/5a/116Horsea.png/250px-116Horsea.png"
@@ -2572,9 +2418,7 @@
     },
     "evolutions": [
       {
-        "id": "119",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/6/6a/119Seaking.png/250px-119Seaking.png",
-        "name": "Seaking"
+        "id": "119"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/7/7b/118Goldeen.png/250px-118Goldeen.png"
@@ -2613,9 +2457,7 @@
     },
     "evolutions": [
       {
-        "id": "121",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/c/cd/121Starmie.png/250px-121Starmie.png",
-        "name": "Starmie"
+        "id": "121"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/4/4f/120Staryu.png/250px-120Staryu.png"
@@ -2773,9 +2615,7 @@
     },
     "evolutions": [
       {
-        "id": "130",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/4/41/130Gyarados.png/250px-130Gyarados.png",
-        "name": "Gyarados"
+        "id": "130"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/0/02/129Magikarp.png/250px-129Magikarp.png"
@@ -2848,19 +2688,13 @@
     },
     "evolutions": [
       {
-        "id": "134",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/f/fd/134Vaporeon.png/250px-134Vaporeon.png",
-        "name": "Vaporeon"
+        "id": "134"
       },
       {
-        "id": "135",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/b/bb/135Jolteon.png/250px-135Jolteon.png",
-        "name": "Jolteon"
+        "id": "135"
       },
       {
-        "id": "136",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/d/dd/136Flareon.png/250px-136Flareon.png",
-        "name": "Flareon"
+        "id": "136"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/e/e2/133Eevee.png/250px-133Eevee.png"
@@ -2950,9 +2784,7 @@
     },
     "evolutions": [
       {
-        "id": "139",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/4/43/139Omastar.png/250px-139Omastar.png",
-        "name": "Omastar"
+        "id": "139"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/7/79/138Omanyte.png/250px-138Omanyte.png"
@@ -2991,9 +2823,7 @@
     },
     "evolutions": [
       {
-        "id": "141",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/2/29/141Kabutops.png/250px-141Kabutops.png",
-        "name": "Kabutops"
+        "id": "141"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/f/f9/140Kabuto.png/250px-140Kabuto.png"
@@ -3117,14 +2947,10 @@
     },
     "evolutions": [
       {
-        "id": "148",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/9/93/148Dragonair.png/250px-148Dragonair.png",
-        "name": "Dragonair"
+        "id": "148"
       },
       {
-        "id": "149",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/8/8b/149Dragonite.png/250px-149Dragonite.png",
-        "name": "Dragonite"
+        "id": "149"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/c/cc/147Dratini.png/250px-147Dratini.png"
@@ -3146,9 +2972,7 @@
     },
     "evolutions": [
       {
-        "id": "149",
-        "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/8/8b/149Dragonite.png/250px-149Dragonite.png",
-        "name": "Dragonite"
+        "id": "149"
       }
     ],
     "imgSrc": "https://cdn.bulbagarden.net/upload/thumb/9/93/148Dragonair.png/250px-148Dragonair.png"

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const { ApolloServer, gql } = require('apollo-server');
 
 const data = require('./data/pokemon.json');
 
-const typeDefs = gql`
+const types = gql`
   """
   Height of the pokemon, ranges between a minimum and maximum value
   """
@@ -19,15 +19,6 @@ const typeDefs = gql`
     maximum: String
   }
 
-  """
-  Details of the evolution, ID can be used for further queries
-  """
-  type Evolution {
-    id: ID!
-    imgSrc: String
-    name: String
-  }
-
   type Pokemon {
     """
     Definiting trait of the Pokemon e.g. "Seed Pokémon"
@@ -38,7 +29,7 @@ const typeDefs = gql`
 
     e.g. [B, C] - A > B > C
     """
-    evolutions: [Evolution]
+    evolutions: [Pokemon]
     height: Height
     """
        ID as in Pokedex
@@ -53,7 +44,9 @@ const typeDefs = gql`
     weaknesses: [String]
     weight: Weight
   }
+`;
 
+const queries = gql`
   type Query {
     pokemon: [Pokemon]!
     """
@@ -86,7 +79,21 @@ const typeDefs = gql`
   }
 `;
 
+const typeDefs = gql`
+  ${types}
+  ${queries}
+`;
+
 const resolvers = {
+  Pokemon: {
+    evolutions: ({ evolutions }) => {
+      if (!evolutions) {
+        return [];
+      }
+
+      return evolutions.map((ev) => data.find((d) => d.id === ev.id));
+    },
+  },
   Query: {
     pokemon: () => data,
     pokemonByName: (_, params) => {


### PR DESCRIPTION
### Previous

- Separate type
- Only `name`, `id`, and `imgSrc` were available

### Now

- Returns a list of `Pokemon` type
- All data available for a `Pokemon` is available
- Trivial resolver handles the lookup based on ID

### Misc

- Split the types and queries in the schema, should allow more granularity in the future (if required)