### PR TITLE
Support cors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM node:12-alpine
 
+ARG CORS_ORIGIN
+
 ENV NODE_ENV=production
 ENV PORT=4000
+ENV CORS_ORIGIN=$CORS_ORIGIN
 
 WORKDIR /server
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ _Push to heroku container registry_
 heroku container:push web -a PROJECT_NAME
 ```
 
+_Build args can be provided with --arg_
+```bash
+heroku container:push web --arg CORS_ORIGIN=localhost:3000 -a PROJECT_NAME
+```
+
 _Release to heroku (go live)_
 ```bash
 heroku container:release web -a PROJECT_NAME

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,3 +1,5 @@
 build:
+  config:
+    CORS_ORIGIN: https:\/\/(jonshort|haylzhill).github.io
   docker:
     web: Dockerfile

--- a/index.js
+++ b/index.js
@@ -123,7 +123,9 @@ const server = new ApolloServer({
   cors: {
     allowedHeaders: 'Content-Type,Authorization',
     methods: 'POST',
-    origin: process.env.CORS_ORIGIN || false,
+    origin: !!process.env.CORS_ORIGIN
+      ? new RegExp(process.env.CORS_ORIGIN)
+      : false,
   },
   introspection: true,
   playground: true,

--- a/index.js
+++ b/index.js
@@ -120,6 +120,11 @@ const resolvers = {
 };
 
 const server = new ApolloServer({
+  cors: {
+    allowedHeaders: 'Content-Type,Authorization',
+    methods: 'POST',
+    origin: process.env.CORS_ORIGIN || false,
+  },
   introspection: true,
   playground: true,
   resolvers,

--- a/index.js
+++ b/index.js
@@ -119,14 +119,22 @@ const resolvers = {
   },
 };
 
+const resolveCorsOptions = () => {
+  if (!process.env.CORS_ORIGIN) {
+    return {};
+  }
+
+  return {
+    cors: {
+      allowedHeaders: 'Content-Type,Authorization',
+      methods: 'POST',
+      origin: new RegExp(process.env.CORS_ORIGIN),
+    },
+  };
+};
+
 const server = new ApolloServer({
-  cors: {
-    allowedHeaders: 'Content-Type,Authorization',
-    methods: 'POST',
-    origin: !!process.env.CORS_ORIGIN
-      ? new RegExp(process.env.CORS_ORIGIN)
-      : false,
-  },
+  ...resolveCorsOptions(),
   introspection: true,
   playground: true,
   resolvers,


### PR DESCRIPTION
Accept `CORS_ORIGIN` env var, which sets the origin in the cors configuration.

Tested by pushing to heroku locally. Only question is whether the `heroku.yml` will pass build arg correctly, need to trust their build system really.